### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -38,7 +38,7 @@ jobs:
 
     # Verify changelog has entry with new version
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         name: ${{ steps.version.outputs.version }}
         tag_name: ${{ steps.version.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adminator-rtl",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "HTML Admin Template",
   "scripts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions to use the latest versions of `actions/checkout` and `actions/setup-node` (v4).
  - Updated GitHub Actions in release workflow to use `softprops/action-gh-release` v2.

- **Version**
  - Updated project version in `package.json` to 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->